### PR TITLE
Fix Windows build by linking Qt Multimedia

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,8 @@ project(veyon-chat-plugin VERSION 1.0.0 LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# Find Qt5 components (Core, Widgets, Network only)
-find_package(Qt5 REQUIRED COMPONENTS Core Widgets Network)
+# Find Qt5 components (Core, Widgets, Network, Multimedia)
+find_package(Qt5 REQUIRED COMPONENTS Core Widgets Network Multimedia)
 
 # Enable Qt MOC, UIC, and RCC
 set(CMAKE_AUTOMOC ON)
@@ -421,6 +421,7 @@ target_link_libraries(veyon-chat-plugin
     Qt5::Core
     Qt5::Widgets
     Qt5::Network
+    Qt5::Multimedia
 )
 
 # Set plugin properties
@@ -442,5 +443,7 @@ message(STATUS "Building Veyon Chat Plugin v${PROJECT_VERSION}")
 message(STATUS "Qt5 Core: ${Qt5Core_VERSION}")
 message(STATUS "Qt5 Widgets: ${Qt5Widgets_VERSION}")
 message(STATUS "Qt5 Network: ${Qt5Network_VERSION}")
+message(STATUS "Qt5 Multimedia: ${Qt5Multimedia_VERSION}")
 message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 message(STATUS "Compiler: ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION}")
+


### PR DESCRIPTION
## Summary
- require the Qt Multimedia module so QSoundEffect headers resolve
- link the plugin target against Qt5::Multimedia and report its version during configuration

## Testing
- not run (Qt5 development packages are unavailable in the container environment)

------
https://chatgpt.com/codex/tasks/task_e_68dd42e9ff4c832f91d0e7386d102b0b