### PR TITLE
Create reusable stubs for Veyon interfaces

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,31 +67,10 @@ file(WRITE "${MOCK_HEADERS_DIR}/FeatureProviderInterface.h"
 #include <QString>
 #include <QKeySequence>
 #include \"Feature.h\"
-
-class Computer {
-public:
-    QString hostAddress() const { return QString(); }
-};
-
-class ComputerControlInterface {
-public:
-    Computer computer() const { return Computer(); }
-    void sendFeatureMessage(const class FeatureMessage&, bool) {}
-};
-typedef QList<ComputerControlInterface*> ComputerControlInterfaceList;
-
-class MessageContext {};
-class VeyonServerInterface {};
-class VeyonWorkerInterface {};
-
-class FeatureMessage {
-public:
-    FeatureMessage(const QString& uid, int command) {}
-    void addArgument(const QString& key, const QVariant& value) {}
-    QVariant argument(const QString& key) const { return QVariant(); }
-    QString featureUid() const { return QString(); }
-    int command() const { return 0; }
-};
+#include \"FeatureMessage.h\"
+#include \"VeyonServerInterface.h\"
+#include \"VeyonWorkerInterface.h\"
+#include \"ComputerControlInterface.h\"
 
 class FeatureProviderInterface {
 public:

--- a/src/ComputerControlInterface.h
+++ b/src/ComputerControlInterface.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <QList>
+#include <QString>
+
+class FeatureMessage;
+
+class Computer
+{
+public:
+    QString hostAddress() const
+    {
+        return QString();
+    }
+};
+
+class ComputerControlInterface
+{
+public:
+    Computer computer() const
+    {
+        return Computer();
+    }
+
+    void sendFeatureMessage(const FeatureMessage& message, bool synchronous)
+    {
+        (void)message;
+        (void)synchronous;
+    }
+};
+
+using ComputerControlInterfaceList = QList<ComputerControlInterface*>;
+

--- a/src/FeatureMessage.h
+++ b/src/FeatureMessage.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <QString>
+#include <QVariant>
+
+class FeatureMessage
+{
+public:
+    FeatureMessage(const QString& uid = QString(), int command = 0)
+    {
+        (void)uid;
+        (void)command;
+    }
+
+    void addArgument(const QString& key, const QVariant& value)
+    {
+        (void)key;
+        (void)value;
+    }
+
+    QVariant argument(const QString& key) const
+    {
+        (void)key;
+        return QVariant();
+    }
+
+    QString featureUid() const
+    {
+        return QString();
+    }
+
+    int command() const
+    {
+        return 0;
+    }
+};
+

--- a/src/VeyonServerInterface.h
+++ b/src/VeyonServerInterface.h
@@ -1,0 +1,10 @@
+#pragma once
+
+class MessageContext
+{
+};
+
+class VeyonServerInterface
+{
+};
+

--- a/src/VeyonWorkerInterface.h
+++ b/src/VeyonWorkerInterface.h
@@ -1,0 +1,6 @@
+#pragma once
+
+class VeyonWorkerInterface
+{
+};
+


### PR DESCRIPTION
## Summary
- add lightweight stub headers for Veyon feature messaging and control interfaces
- update the generated FeatureProviderInterface shim to include the shared headers and avoid duplicate declarations

## Testing
- cmake -S . -B build *(fails: Qt5 development packages not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd4d6f4d70832f97700cbc1ddcdf28