### PR TITLE
Fix Qt signal connections and client identifier initialization

### DIFF
--- a/src/ChatClientWidget.cpp
+++ b/src/ChatClientWidget.cpp
@@ -11,6 +11,7 @@
 #include <QPushButton>
 #include <QSettings>
 #include <QShortcut>
+#include <QSoundEffect>
 #include <QSystemTrayIcon>
 #include <QTextCursor>
 #include <QTextEdit>
@@ -39,7 +40,7 @@ ChatClientWidget::ChatClientWidget(QWidget* parent) :
     m_typingTimer(new QTimer(this)),
     m_notificationSound(new QSoundEffect(this)),
     m_soundEnabled(true),
-    m_clientId(QStringLiteral(CLIENT_ID)),
+    m_clientId(QString::fromLatin1(CLIENT_ID)),
     m_unreadCount(0)
 {
     setObjectName(QStringLiteral("ChatClientWidget"));

--- a/src/ChatMasterWidget.cpp
+++ b/src/ChatMasterWidget.cpp
@@ -400,7 +400,9 @@ void ChatMasterWidget::setupUI()
     m_splitter->setStretchFactor(0, 1);
     m_splitter->setStretchFactor(1, 2);
 
-    connect(m_quickReplies, &QComboBox::currentIndexChanged, this, [this](int index) {
+    connect(m_quickReplies,
+            static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
+            [this](int index) {
         if (index <= 0) {
             return;
         }


### PR DESCRIPTION
## Summary
- disambiguate the quick reply combo box signal connection to avoid MSVC overload resolution errors
- initialise the client identifier without relying on QStringLiteral macros
- include the missing QSoundEffect header to satisfy the compiler

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd646a8e94832fa9cb82beb0a39c58