### PR TITLE
Fix Qt signal overload handling and enable C++20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,9 @@ cmake_minimum_required(VERSION 3.16)
 project(veyon-chat-plugin VERSION 1.0.0 LANGUAGES CXX)
 
 # Set C++ standard
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Find Qt5 components (Core, Widgets, Network, Multimedia)
 find_package(Qt5 REQUIRED COMPONENTS Core Widgets Network Multimedia)

--- a/src/ChatClientWidget.cpp
+++ b/src/ChatClientWidget.cpp
@@ -23,7 +23,6 @@ constexpr auto ORGANIZATION_NAME = "Veyon";
 constexpr auto APPLICATION_NAME = "ChatClient";
 constexpr auto SETTINGS_GEOMETRY = "geometry";
 constexpr auto SETTINGS_SOUND = "soundEnabled";
-constexpr auto CLIENT_ID = "client";
 constexpr auto MASTER_ID = "master";
 }
 
@@ -39,7 +38,7 @@ ChatClientWidget::ChatClientWidget(QWidget* parent) :
     m_typingTimer(new QTimer(this)),
     m_notificationSound(new QSoundEffect(this)),
     m_soundEnabled(true),
-    m_clientId(QStringLiteral(CLIENT_ID)),
+    m_clientId(QStringLiteral("client")),
     m_unreadCount(0)
 {
     setObjectName(QStringLiteral("ChatClientWidget"));

--- a/src/ChatMasterWidget.cpp
+++ b/src/ChatMasterWidget.cpp
@@ -22,6 +22,7 @@
 #include <QTimer>
 #include <QUrl>
 #include <QVBoxLayout>
+#include <QtCore/QOverload>
 
 namespace {
 constexpr auto ORGANIZATION_NAME = "Veyon";
@@ -404,7 +405,10 @@ void ChatMasterWidget::setupUI()
     m_splitter->setStretchFactor(0, 1);
     m_splitter->setStretchFactor(1, 2);
 
-    connect(m_quickReplies, &QComboBox::currentIndexChanged, this, [this](int index) {
+    connect(m_quickReplies,
+            qOverload<int>(&QComboBox::currentIndexChanged),
+            this,
+            [this](int index) {
         if (index <= 0) {
             return;
         }


### PR DESCRIPTION
## Summary
- disambiguate the quick reply combo box signal connection with qOverload and include the corresponding header
- replace QStringLiteral usage with a true string literal for the client identifier
- raise the project C++ standard requirement to C++20 and disable compiler extensions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd74e9ddc8832f8e6ae5210b29fc68