### PR TITLE
Fix ChatMasterWidget Qt include

### DIFF
--- a/src/ChatMasterWidget.cpp
+++ b/src/ChatMasterWidget.cpp
@@ -3,6 +3,7 @@
 #include <QApplication>
 #include <QAbstractItemView>
 #include <QAction>
+#include <QtCore/qobjectdefs.h>
 #include <QComboBox>
 #include <QDateTime>
 #include <QHBoxLayout>


### PR DESCRIPTION
## Summary
- replace the QtCore/QOverload include with QtCore/qobjectdefs.h so builds with Qt 5.15

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd7743d758832fb0f3777cbbd6039f