### PR TITLE
Ensure F10 shortcut works application-wide

### DIFF
--- a/src/ChatClientWidget.cpp
+++ b/src/ChatClientWidget.cpp
@@ -235,6 +235,7 @@ void ChatClientWidget::setupTrayIcon()
 void ChatClientWidget::setupShortcuts()
 {
     m_f10Shortcut = new QShortcut(QKeySequence(Qt::Key_F10), this);
+    m_f10Shortcut->setContext(Qt::ApplicationShortcut);
     connect(m_f10Shortcut, &QShortcut::activated, this, [this]() {
         if (isHidden()) {
             showNormal();

--- a/src/ChatMasterWidget.cpp
+++ b/src/ChatMasterWidget.cpp
@@ -443,6 +443,7 @@ void ChatMasterWidget::setupTrayIcon()
 void ChatMasterWidget::setupShortcuts()
 {
     m_f10Shortcut = new QShortcut(QKeySequence(Qt::Key_F10), this);
+    m_f10Shortcut->setContext(Qt::ApplicationShortcut);
     connect(m_f10Shortcut, &QShortcut::activated, this, [this]() {
         if (isHidden()) {
             showNormal();


### PR DESCRIPTION
## Summary
- set the chat window F10 shortcuts to use the application context on both client and master widgets so the hotkey works even when the window is not focused

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de9424c3ac832f8a745ce821d8a023