### PR TITLE
Use real Veyon headers and fetch dependencies in CI

### DIFF
--- a/.github/workflows/build-windows-qt-fixed.yml
+++ b/.github/workflows/build-windows-qt-fixed.yml
@@ -7,201 +7,82 @@ on:
     branches: [ main, master ]
   workflow_dispatch:
 
+env:
+  VEYON_TAG: v4.9.7
+
 jobs:
   build-windows:
     runs-on: windows-latest
-    
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-      
+
     - name: Setup MSBuild
       uses: microsoft/setup-msbuild@v2
-      
-    - name: Setup Qt (Corrected)
+
+    - name: Setup Qt (5.15.2, MSVC2019 x64)
       shell: powershell
       run: |
-        Write-Host "Installing aqtinstall..."
         python -m pip install --upgrade pip
         python -m pip install aqtinstall
-        
-        Write-Host "Installing Qt 5.15.2 (base components only)..."
         python -m aqt install-qt windows desktop 5.15.2 win64_msvc2019_64
-        
-        Write-Host "Setting up Qt environment..."
         $QtPath = "$env:GITHUB_WORKSPACE\5.15.2\msvc2019_64"
         echo "Qt5_DIR=$QtPath\lib\cmake\Qt5" >> $env:GITHUB_ENV
         echo "$QtPath\bin" >> $env:GITHUB_PATH
-        
-        Write-Host "Verifying Qt installation..."
-        if (Test-Path "$QtPath\bin\qmake.exe") {
-          Write-Host "✅ Qt installed successfully at: $QtPath"
-          & "$QtPath\bin\qmake.exe" -version
-          
-          Write-Host "Available Qt modules:"
-          Get-ChildItem "$QtPath\lib\cmake" | Select-Object Name
-        } else {
-          Write-Host "❌ Qt installation failed"
-          Write-Host "Contents of workspace:"
-          Get-ChildItem $env:GITHUB_WORKSPACE -Recurse -Directory | Where-Object {$_.Name -like "*qt*" -or $_.Name -like "*5.15*"}
-          exit 1
-        }
-        
+        & "$QtPath\bin\qmake.exe" -version
+
+    - name: Fetch Veyon 4.9.7 headers
+      shell: powershell
+      run: |
+        git clone --depth 1 --branch $env:VEYON_TAG https://github.com/veyon/veyon.git veyon-src
+        if (-not (Test-Path "veyon-src/src/plugins")) { Write-Error "Unexpected Veyon layout"; exit 1 }
+        echo "VEYON_SOURCE_DIR=$env:GITHUB_WORKSPACE\veyon-src" >> $env:GITHUB_ENV
+
     - name: Create build directory
       run: mkdir build
-      
+
     - name: Configure CMake
       shell: powershell
       run: |
         cd build
-        $QtDir = $env:Qt5_DIR
-        Write-Host "Using Qt5_DIR: $QtDir"
-        
-        Write-Host "Running CMake configuration..."
         cmake -G "Visual Studio 17 2022" -A x64 `
           -DCMAKE_BUILD_TYPE=Release `
-          -DQt5_DIR="$QtDir" `
+          -DQt5_DIR="$env:Qt5_DIR" `
           -DCMAKE_PREFIX_PATH="$env:GITHUB_WORKSPACE\5.15.2\msvc2019_64" `
+          -DVEYON_SOURCE_DIR="$env:VEYON_SOURCE_DIR" `
           ..
-          
-        if ($LASTEXITCODE -ne 0) {
-          Write-Host "❌ CMake configuration failed"
-          Write-Host "Available CMake files:"
-          Get-ChildItem "$env:GITHUB_WORKSPACE\5.15.2\msvc2019_64\lib\cmake" -Recurse | Where-Object {$_.Name -like "*.cmake"}
-          exit 1
-        }
-      
+
     - name: Build plugin
       shell: powershell
       run: |
         cd build
-        Write-Host "Building plugin..."
         cmake --build . --config Release --parallel
-        
-        if ($LASTEXITCODE -ne 0) {
-          Write-Host "❌ Build failed"
-          Write-Host "Build directory contents:"
-          Get-ChildItem -Recurse . | Select-Object FullName
-          exit 1
-        }
-        
-    - name: Verify DLL creation
+
+    - name: Prepare release-package
       shell: powershell
       run: |
-        Write-Host "Checking for DLL..."
-        $possiblePaths = @(
-          "build/Release/veyon-chat-plugin.dll",
-          "build/veyon-chat-plugin.dll",
-          "build/Release/Debug/veyon-chat-plugin.dll"
-        )
-        
-        $dllFound = $false
-        foreach ($path in $possiblePaths) {
-          if (Test-Path $path) {
-            Write-Host "✅ DLL found at: $path"
-            Get-Item $path | Select-Object Name, Length, LastWriteTime
-            $dllFound = $true
-            
-            # Copy to standard location for packaging
-            Copy-Item $path "veyon-chat-plugin.dll"
-            break
-          }
-        }
-        
-        if (-not $dllFound) {
-          Write-Host "❌ DLL not found in any expected location"
-          Write-Host "Searching entire build directory:"
-          Get-ChildItem -Recurse build -Include "*.dll", "*.exe" | Select-Object FullName, Length
-          exit 1
-        }
-      
-    - name: Create installation files
-      shell: powershell
-      run: |
-        Write-Host "Creating release package..."
-        New-Item -ItemType Directory -Path "release-package" -Force
-        
-        # Copy DLL (from root where we copied it in previous step)
-        if (Test-Path "veyon-chat-plugin.dll") {
-          Copy-Item "veyon-chat-plugin.dll" "release-package/"
-          Write-Host "✅ DLL copied to release package"
-        } else {
-          Write-Host "❌ DLL not found for packaging"
-          exit 1
-        }
-        
-    - name: Create install script
-      shell: powershell
-      run: |
-        $installContent = @(
-          '@echo off',
-          'echo Installing Veyon Chat Plugin...',
-          'if not exist "C:\Program Files\Veyon\plugins" mkdir "C:\Program Files\Veyon\plugins"',
-          'copy veyon-chat-plugin.dll "C:\Program Files\Veyon\plugins\"',
-          'if %errorlevel% equ 0 (',
-          '  echo ✅ Plugin installed successfully!',
-          '  echo Please restart Veyon Master and Service.',
-          ') else (',
-          '  echo ❌ Installation failed. Please check permissions.',
-          ')',
-          'pause'
-        )
-        
-        $installContent | Out-File -FilePath "release-package/install.bat" -Encoding ASCII
-        Write-Host "✅ Install script created"
-        
-    - name: Create README
-      shell: powershell
-      run: |
-        $readmeContent = @(
-          '# Veyon Chat Plugin - Windows Release',
-          '',
-          '## Installation Instructions',
-          '',
-          '1. Extract all files to a folder',
-          '2. Right-click install.bat and select "Run as administrator"',
-          '3. Restart Veyon Master application',
-          '4. Press F10 to open chat window',
-          '',
-          '## Features',
-          '',
-          '- Real-time chat between teacher and students',
-          '- F10 hotkey to open/close chat',
-          '- Global broadcast messages',
-          '- Private messaging',
-          '- Message timestamps',
-          '',
-          '## Files Included',
-          '',
-          '- veyon-chat-plugin.dll - The plugin file',
-          '- install.bat - Automated installation script',
-          '',
-          '## Requirements',
-          '',
-          '- Veyon 4.9.7 installed',
-          '- Windows 10/11',
-          '- Administrator privileges for installation',
-          '',
-          '## Support',
-          '',
-          'For issues or questions, visit:',
-          'https://github.com/PhotographerSeth/Veyon'
-        )
-        
-        $readmeContent | Out-File -FilePath "release-package/README.txt" -Encoding UTF8
-        Write-Host "✅ README created"
-        
-    - name: Create ZIP package
-      shell: powershell
-      run: |
-        Write-Host "Creating ZIP package..."
-        Compress-Archive -Path "release-package/*" -DestinationPath "veyon-chat-plugin-windows.zip" -Force
-        
-        Write-Host "✅ Package created successfully"
-        Write-Host "Package contents:"
-        Get-ChildItem "release-package" | Select-Object Name, Length
-        
-    - name: Upload plugin artifacts
+        New-Item -ItemType Directory -Path "release-package" -Force | Out-Null
+        $dll = Get-ChildItem -Recurse build -Filter veyon-chat-plugin.dll | Select-Object -First 1
+        if (-not $dll) { Write-Error "DLL not found"; exit 1 }
+        Copy-Item $dll.FullName "release-package\veyon-chat-plugin.dll"
+        @"
+@echo off
+echo Installing Veyon Chat Plugin...
+if not exist "C:\Program Files\Veyon\plugins" mkdir "C:\Program Files\Veyon\plugins"
+copy /Y veyon-chat-plugin.dll "C:\Program Files\Veyon\plugins\"
+echo Done. Restart Veyon Master/Service.
+"@ | Out-File -FilePath "release-package\install.bat" -Encoding ASCII
+        @"
+# Veyon Chat Plugin - Windows (for Veyon 4.9.7)
+
+1) Run `install.bat` as Administrator
+2) Restart **Veyon Service** (clients) and **Veyon Master** (teacher)
+3) Open Veyon and verify the plugin appears under Plugins
+"@ | Out-File -FilePath "release-package\README.txt" -Encoding UTF8
+        Compress-Archive -Path "release-package\*" -DestinationPath "veyon-chat-plugin-windows.zip" -Force
+
+    - name: Upload artifacts
       uses: actions/upload-artifact@v4
       with:
         name: veyon-chat-plugin-windows
@@ -209,11 +90,5 @@ jobs:
           release-package/veyon-chat-plugin.dll
           release-package/install.bat
           release-package/README.txt
-        retention-days: 90
-        
-    - name: Upload complete package
-      uses: actions/upload-artifact@v4
-      with:
-        name: veyon-chat-plugin-complete-package
-        path: veyon-chat-plugin-windows.zip
+          veyon-chat-plugin-windows.zip
         retention-days: 90

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,12 +2,23 @@ cmake_minimum_required(VERSION 3.16)
 
 project(veyon-chat-plugin VERSION 1.0.0 LANGUAGES CXX)
 
-# Set C++ standard
-set(CMAKE_CXX_STANDARD 17)
+# C++ & Qt
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
-# Find Qt5 components (Core, Widgets, Network, Multimedia)
 find_package(Qt5 REQUIRED COMPONENTS Core Widgets Network Multimedia)
+
+# Path to the real Veyon 4.9.7 source tree (provided by CI or your local env)
+set(VEYON_SOURCE_DIR "" CACHE PATH "Path to the Veyon sources (4.9.7)")
+if(NOT VEYON_SOURCE_DIR)
+  if(DEFINED ENV{VEYON_SOURCE_DIR})
+    set(VEYON_SOURCE_DIR $ENV{VEYON_SOURCE_DIR})
+  else()
+    message(FATAL_ERROR "Set VEYON_SOURCE_DIR to the path of the Veyon sources (4.9.7).")
+  endif()
+endif()
+
 
 # Enable Qt MOC, UIC, and RCC
 set(CMAKE_AUTOMOC ON)
@@ -17,106 +28,8 @@ set(CMAKE_AUTORCC ON)
 # Set UI files directory
 set(CMAKE_AUTOUIC_SEARCH_PATHS ui)
 
-# Create mock Veyon headers directory
-set(MOCK_HEADERS_DIR "${CMAKE_CURRENT_BINARY_DIR}/mock-headers")
-file(MAKE_DIRECTORY "${MOCK_HEADERS_DIR}")
-
-# Create Feature.h mock header (missing from previous version)
-file(WRITE "${MOCK_HEADERS_DIR}/Feature.h"
-"#pragma once
-#include <QString>
-#include <QKeySequence>
-
-class Feature {
-public:
-    typedef QString Uid;
-    enum Flag { 
-        None = 0, Mode = 1, Action = 2, Session = 4, Meta = 8, 
-        Option = 16, Checked = 32, Master = 256, Service = 512, 
-        Worker = 1024, Builtin = 4096 
-    };
-    
-    Feature() = default;
-    Feature(Uid uid, int flags, QString name, QString displayName, 
-            QString displayNameActive, QString description, 
-            QString iconUrl, QKeySequence shortcut)
-        : m_uid(uid), m_flags(flags), m_name(name), m_displayName(displayName) {}
-    
-    Uid uid() const { return m_uid; }
-    int flags() const { return m_flags; }
-    QString name() const { return m_name; }
-    QString displayName() const { return m_displayName; }
-    
-private:
-    Uid m_uid;
-    int m_flags = 0;
-    QString m_name;
-    QString m_displayName;
-};
-
-typedef QList<Feature> FeatureList;
-")
-
-# Create comprehensive mock Veyon headers with proper Qt interface declarations
-file(WRITE "${MOCK_HEADERS_DIR}/FeatureProviderInterface.h"
-"#pragma once
-#include <QObject>
-#include <QVersionNumber>
-#include <QVariantMap>
-#include <QList>
-#include <QString>
-#include <QKeySequence>
-#include \"Feature.h\"
-#include \"FeatureMessage.h\"
-#include \"VeyonServerInterface.h\"
-#include \"VeyonWorkerInterface.h\"
-#include \"ComputerControlInterface.h\"
-
-class FeatureProviderInterface {
-public:
-    enum Operation { Start, Stop };
-    virtual ~FeatureProviderInterface() = default;
-    virtual const FeatureList& featureList() const = 0;
-    virtual bool controlFeature(Feature::Uid, Operation, const QVariantMap&, const ComputerControlInterfaceList&) = 0;
-    virtual bool handleFeatureMessage(VeyonServerInterface&, const MessageContext&, const FeatureMessage&) = 0;
-    virtual bool handleFeatureMessage(VeyonWorkerInterface&, const FeatureMessage&) = 0;
-};
-
-// Qt interface declaration for MOC
-Q_DECLARE_INTERFACE(FeatureProviderInterface, \"org.veyon.FeatureProviderInterface\")
-")
-
-file(WRITE "${MOCK_HEADERS_DIR}/PluginInterface.h"
-"#pragma once
-#include <QObject>
-#include <QVersionNumber>
-#include <QString>
-
-class Plugin {
-public:
-    typedef QString Uid;
-};
-
-class PluginInterface {
-public:
-    virtual ~PluginInterface() = default;
-    virtual Plugin::Uid uid() const = 0;
-    virtual QVersionNumber version() const = 0;
-    virtual QString name() const = 0;
-    virtual QString description() const = 0;
-    virtual QString vendor() const = 0;
-    virtual QString copyright() const = 0;
-    virtual QString shortName() const = 0;
-    virtual void upgrade(const QVersionNumber&) = 0;
-};
-
-// Qt interface declaration for MOC
-Q_DECLARE_INTERFACE(PluginInterface, \"org.veyon.PluginInterface\")
-")
-
-# Include mock headers
-include_directories("${MOCK_HEADERS_DIR}")
-include_directories(src)
+# Include project headers
+set(PROJECT_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src")
 
 # Source files (ONLY the .cpp files that actually exist in your repository)
 set(SOURCES
@@ -161,16 +74,22 @@ add_library(veyon-chat-plugin SHARED
     ${RESOURCES}
 )
 
-# Link Qt libraries
-target_link_libraries(veyon-chat-plugin
-    Qt5::Core
-    Qt5::Widgets
-    Qt5::Network
-    Qt5::Multimedia
+# Use Veyon's real headers (interfaces live under src/ and src/plugins/)
+target_include_directories(veyon-chat-plugin PRIVATE
+    ${PROJECT_INCLUDE_DIR}
+    ${VEYON_SOURCE_DIR}/src
+    ${VEYON_SOURCE_DIR}/src/plugins
+)
+
+# Link Qt and user32 (for global hotkey)
+target_link_libraries(veyon-chat-plugin PRIVATE
+    Qt5::Core Qt5::Widgets Qt5::Network Qt5::Multimedia
+    user32
 )
 
 # Set plugin properties
 set_target_properties(veyon-chat-plugin PROPERTIES
+    OUTPUT_NAME "veyon-chat-plugin"
     PREFIX ""
     SUFFIX ".dll"
 )


### PR DESCRIPTION
## Summary
- configure CMake to consume Veyon 4.9.7 headers directly and link against the required Qt modules
- drop the temporary mock header generation logic and enforce C++20
- update the Windows workflow to clone the Veyon sources and pass VEYON_SOURCE_DIR to CMake

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dea1722ae8832f87cf2952305ecbb9